### PR TITLE
Use status LEDs in ranging examples

### DIFF
--- a/examples/dw1000_ranging_anchor.rs
+++ b/examples/dw1000_ranging_anchor.rs
@@ -85,6 +85,10 @@ fn main() -> ! {
         repeat_timeout!(
             &mut task_timer,
             {
+                dwm1001.leds.D10.enable();
+                delay.delay_ms(10u32);
+                dwm1001.leds.D10.disable();
+
                 let mut future = dw1000
                     .receive()
                     .expect("Failed to receive message");
@@ -102,6 +106,10 @@ fn main() -> ! {
                 })
             },
             (message) {
+                dwm1001.leds.D10.enable();
+                delay.delay_ms(10u32);
+                dwm1001.leds.D10.disable();
+
                 let request = ranging::Request::decode::<Spim<SPIM2>>(&message);
 
                 let request = match request {
@@ -112,6 +120,10 @@ fn main() -> ! {
                         continue;
                     }
                 };
+
+                dwm1001.leds.D11.enable();
+                delay.delay_ms(10u32);
+                dwm1001.leds.D11.disable();
 
                 // Send ranging response
                 let mut future = ranging::Response::new(&mut dw1000, request)
@@ -130,6 +142,10 @@ fn main() -> ! {
                     future.wait()
                 })
                 .expect("Failed to send ranging response");
+
+                dwm1001.leds.D12.enable();
+                delay.delay_ms(10u32);
+                dwm1001.leds.D12.disable();
             };
             (_error) {
                 // ignore

--- a/examples/dw1000_ranging_tag.rs
+++ b/examples/dw1000_ranging_tag.rs
@@ -84,6 +84,10 @@ fn main() -> ! {
         repeat_timeout!(
             &mut task_timer,
             {
+                dwm1001.leds.D10.enable();
+                delay.delay_ms(10u32);
+                dwm1001.leds.D10.disable();
+
                 let mut future = dw1000
                     .receive()
                     .expect("Failed to receive message");
@@ -114,6 +118,10 @@ fn main() -> ! {
                     future.enable_interrupts()
                         .expect("Failed to enable interrupts");
 
+                    dwm1001.leds.D11.enable();
+                    delay.delay_ms(10u32);
+                    dwm1001.leds.D11.disable();
+
                     timeout_timer.start(100_000u32);
                     block!({
                         dw_irq.wait_for_interrupts(
@@ -132,6 +140,10 @@ fn main() -> ! {
                     ranging::Response::decode::<Spim<SPIM2>>(&message)
                         .expect("Failed to decode response");
                 if let Some(response) = response {
+                    dwm1001.leds.D12.enable();
+                    delay.delay_ms(10u32);
+                    dwm1001.leds.D12.disable();
+
                     // If this is not a PAN ID and short address, it doesn't
                     // come from a compatible node. Ignore it.
                     let (pan_id, addr) = match response.source {
@@ -144,6 +156,10 @@ fn main() -> ! {
                     // Ranging response received. Compute distance.
                     match ranging::compute_distance_mm(&response) {
                         Some(distance_mm) => {
+                            dwm1001.leds.D9.enable();
+                            delay.delay_ms(10u32);
+                            dwm1001.leds.D9.disable();
+
                             print!("{:04x}:{:04x} - {} mm\n",
                                 pan_id.0,
                                 addr.0,


### PR DESCRIPTION
The delays don't seem to impede the operation, and this makes them much easier to debug.